### PR TITLE
Handle null raw password on manager registration

### DIFF
--- a/Laboratorio 02/Codigo/FrontEnd/gestor.html
+++ b/Laboratorio 02/Codigo/FrontEnd/gestor.html
@@ -113,7 +113,7 @@
                                             <select class="form-select" id="gestor-agente-tipo">
                                                 <option value="">Selecione o tipo</option>
                                                 <option value="BANCO">Banco</option>
-                                                <option value="EMPRESA">Empresa</option>
+                                                <option value="EMPRESA">Empresa Financeira</option>
                                             </select>
                                         </div>
                                     </div>

--- a/Laboratorio 02/Codigo/FrontEnd/scripts/gestor.js
+++ b/Laboratorio 02/Codigo/FrontEnd/scripts/gestor.js
@@ -197,13 +197,17 @@ class GestorService {
     }
 
     async cadastrarAgente(data) {
+        const tipoAgenteBackend = data.agenteTipo === 'EMPRESA' ? 'EMPRESA_FINANCEIRA' : data.agenteTipo;
+
         const agenteData = {
             nome: data.nome,
             cnpj: data.cnpj || '',
             endereco: data.endereco || '',
             telefone: data.telefone || '',
-            tipoAgente: data.agenteTipo,
-            ativo: data.ativo
+            tipoAgente: tipoAgenteBackend,
+            ativo: data.ativo,
+            email: data.email,
+            password: data.senha
         };
 
         return await apiService.cadastrarAgente(agenteData);


### PR DESCRIPTION
Fix agent registration by including `email` and `password` in the payload and mapping `tipoAgente` to backend enum values.

This resolves the "rawPassword cannot be null" error encountered during agent registration, which occurred because the `email` and `password` fields were not being sent from the frontend, and the `tipoAgente` value "EMPRESA" needed to be mapped to "EMPRESA_FINANCEIRA" for backend compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-e49c575d-6afe-4362-97f9-e523cc7b9a7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e49c575d-6afe-4362-97f9-e523cc7b9a7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

